### PR TITLE
Add support for React 19

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm ci
 
       - name: Install react
-        run: npm install react@${{ matrix.react-version }}
+        run: npm install react@${{ matrix.react-version }} react-dom@${{ matrix.react-version }}
 
       - name: Lint, format and type check
         run: npm run verify

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x, 22.x]
-        react-version: [18.0, 18.1, 18.2, 18.3, 19.0]
+        react-version: ['18.0.*', '18.1.*', '18.2.*', '18.3.*', '19.0.*']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
         react-version: [18.0, 18.1, 18.2, 18.3, 19.0]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x, 22.x]
-        react-version: ['18.0.*', '18.1.*', '18.2.*', '18.3.*', '19.0.*']
+        react-version: ['18.*', '19.*']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x, 22.x]
+        react-version: [18.0, 18.1, 18.2, 18.3, 19.0]
 
     steps:
       - uses: actions/checkout@v2
@@ -28,6 +29,9 @@ jobs:
 
       - name: Install
         run: npm ci
+
+      - name: Install react
+        run: npm install react@${{ matrix.react-version }}
 
       - name: Lint, format and type check
         run: npm run verify

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "node": ">= 16.12.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "vitest": "^2.1.5"
   },
   "peerDependencies": {
-    "react": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0"
   },
   "engines": {
     "node": ">= 16.12.0"


### PR DESCRIPTION
Closes https://github.com/i-like-robots/react-tag-autocomplete/issues/78

This PR is primarily focused on allowing this package to be installed with React 19, by updating the peer dependency constraint to `^18.0.0 || ^19.0.0`.

On top of that, this PR adds a few extra improvements:

1. Update actions used in the test workflow to their latest versions.
2. Ensure test workflow is run for every supported React minor version.

There's an open question though: The project defines a peer dependency on react, but dev dependencies on react and react-dom. I have only updated the peer dependency, but it probably makes sense to keep those in sync.

However, when using npm, you can skip duplicating dev and peer dependencies, as it installs peer dependencies if it's not explicitly defined anywhere else. That would require defining react-dom as a peer dependency though, which probably makes sense, but I'm not sure if it would be a breaking change. 